### PR TITLE
add subtractBox option

### DIFF
--- a/examples/subtract-box/index.html
+++ b/examples/subtract-box/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>A-Frame 3D Tiles Component - Basic example</title>
+    <meta name="description" content="Basic example for 3D Tiles component showing google 3d Tiles."></meta>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
+    <script src="../../dist/aframe-loader-3dtiles-component.js"></script>
+    <!-- <script src="https://unpkg.com/3dstreet@0.4.5/dist/aframe-street-component.js"></script> -->
+
+        <!-- vr teleport controls -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls@0.4.3/dist/aframe-blink-controls.min.js"></script> -->
+    <style>
+      #guide {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 300px;
+        padding: 1rem 2rem;
+        font-family:'Courier New', Courier, monospace;
+        line-height: 1.2;
+        background-color: white;
+        color: black;
+      }
+
+      #guide p {
+        margin-top: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <a-scene vr-mode-ui="enabled: false" renderer="colorManagement: true;">
+      <a-entity camera="fov:45; near:1; far: 1000" look-controls="reverseMouseDrag: true" wasd-controls="enabled: true" id="camera" cursor-teleport="cameraRig: #camera; cameraHead: #camera;"></a-entity>
+      <a-entity
+        id="tileset"
+        loader-3dtiles="
+          url: https://tile.googleapis.com/v1/3dtiles/root.json; 
+          lat: 37.77522354250163;
+          long: -122.41931773049723;
+          height: 50;
+          googleApiKey: AIzaSyAQshwLVKTpwTfPJxFEkEzOdP_cgmixTCQ;
+          geoTransform: WGS84Cartesian;
+          maximumSSE: 48; 
+          maximumMem: 400;
+          cameraEl: #camera;
+          subtractBox: #subtract"
+      >
+      </a-entity>
+
+      <a-box id="subtract" position="0 -10 0" geometry="depth:60; height:20; width:32" material="transparent: true; opacity:0.5"></a-box>
+
+    </a-scene>
+
+    <!-- GitHub Corner. -->
+    <a href="https://github.com/nytimes/aframe-loader-3dtiles-component" class="github-corner">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#222; color:#fff; position: absolute; top: 0; border: 0; right: 0;">
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+      </svg>
+    </a>
+    <div id="guide">
+      <span id="example-desc">
+        <b>Google 3D Tiles example.</b>
+      </span>
+      <p>Use arrow/WASD keys to move around and click and drag to turn/rotate the camera.</p>
+      <p>
+        <u>Available component parameters:</u>
+        <ul>
+          <li><b>lat, long</b>: coordinates of Google Map.</li>
+          <li><b>height</b>: camera height.</li>
+          <li><b>googleApiKey</b>: Google Api Key.</li>
+        </ul>
+      </p>
+    </div>
+    <script>
+        const queryParams = new URLSearchParams(document.location.search);
+
+        if (queryParams.get('tilesetUrl')) {
+            document.querySelector('#tileset').addEventListener('object3dset', (e) => {
+                e.target.setAttribute('loader-3dtiles', {
+                    url: queryParams.get('tilesetUrl')
+                })
+            })
+        }
+    </script>
+    <style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+    <!-- End GitHub Corner. -->
+  </body>
+</html>


### PR DESCRIPTION
Hi @Avnerus! 
We at 3DStreet would be glad to get your advice on the best way to solve another important task for us. 
I'm trying to add a subtractBox selector attribute to component so that the content of tiles intersected with that Box will not be drawn. I'm trying to do this using shaders for now. This approach works on a simple example with two boxes or other objects.
The question is how to add shaders to the tiles material in the right way. I discovered the `shaderCallback` function in three-loader-3diles options. I use it to add shaders to the tiles material using `material.onBeforeCompile`. I get this strange result in the screenshot. The white box is the clipping area.
![image](https://github.com/nytimes/aframe-loader-3dtiles-component/assets/32197767/f52a1400-7649-4741-a165-372f8db11e51)

- It looks like somewhere transformations are applied to tiles that give this result. 
- It looks like the tiles are cloned and the fragmentShader is applied to all instances.
- The uniforms parameters are not updated for the material. 
- Textures look darker.

Will be great if you give some advices about this task!