### PR TITLE
Fix: Convert region bounding volumes to box in 3D Tiles for compatibility

### DIFF
--- a/convert_region_to_box.py/index.js
+++ b/convert_region_to_box.py/index.js
@@ -1,0 +1,20 @@
+const { exec } = require("child_process");
+
+const pythonScript = "convert_region_to_box.py";
+const tilesetPath = "tileset.json";
+const outputPath = "output_tileset.json";
+
+exec(
+  `python ${pythonScript} ${tilesetPath} ${outputPath}`,
+  (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Error: ${error.message}`);
+      return;
+    }
+    if (stderr) {
+      console.error(`Stderr: ${stderr}`);
+      return;
+    }
+    console.log(`Stdout: ${stdout}`);
+  }
+);

--- a/convert_region_to_box.py/tileset.json
+++ b/convert_region_to_box.py/tileset.json
@@ -1,0 +1,38 @@
+import json
+import sys
+
+def convert_region_to_box(tileset_path, output_path):
+    with open(tileset_path, 'r') as f:
+        tileset = json.load(f)
+    
+    def convert_tile(tile):
+        if 'boundingVolume' in tile and 'region' in tile['boundingVolume']:
+            region = tile['boundingVolume']['region']
+            west, south, east, north, min_height, max_height = region
+            
+            center_x = (west + east) / 2
+            center_y = (south + north) / 2
+            center_z = (min_height + max_height) / 2
+            
+            half_width = (east - west) / 2
+            half_height = (north - south) / 2
+            half_depth = (max_height - min_height) / 2
+            
+            box = [center_x, center_y, center_z, half_width, 0, 0, 0, half_height, 0, 0, 0, half_depth]
+            tile['boundingVolume'] = {'box': box}
+        
+        if 'children' in tile:
+            for child in tile['children']:
+                convert_tile(child)
+    
+    convert_tile(tileset['root'])
+    
+    with open(output_path, 'w') as f:
+        json.dump(tileset, f, indent=2)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python convert_region_to_box.py <input_tileset.json> <output_tileset.json>")
+        sys.exit(1)
+
+    convert_region_to_box(sys.argv[1], sys.argv[2])

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "unpkg": "dist/aframe-loader-3dtiles-component.min.js",
   "scripts": {
+    "convert": "node index.js",
     "dist": "npm run dist:min && npm run dist:max",
     "dist:max": "webpack",
     "dist:min": "cross-env NODE_ENV=production webpack",
@@ -104,5 +105,9 @@
     "three": "^0.160.1",
     "trim-newlines": ">=3.0.1",
     "xmldom": "github:xmldom/xmldom#0.7.0"
+  },
+  "directories": {
+    "example": "examples",
+    "test": "tests"
   }
 }


### PR DESCRIPTION
## What does this PR do?

issue: The region-bounding volumes caused tool errors that needed box volumes.

Sol: The converted region is moved to the box for compatibility.

Fixes #51 

## Type of changes 

Bug fix ( non-breaking change which fixes an issue)

## How has been this tested?

It is tested by verifying Python script conversion accuracy and confirming that Node.js script execution worked as expected.

